### PR TITLE
#27: Made revision logs compulsory

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -40,6 +40,7 @@ module:
   path_alias: 0
   pdf: 0
   realname: 0
+  require_revision_log_message: 0
   rest: 0
   serialization: 0
   system: 0

--- a/config/sync/require_revision_log_message.adminsettings.yml
+++ b/config/sync/require_revision_log_message.adminsettings.yml
@@ -1,0 +1,18 @@
+_core:
+  default_config_hash: 4K3GX7fdi-DT3gftTrhajgcGMmOyY7-4Ivsn4tiPyug
+dependencies:
+  module:
+    - require_revision_log_message
+content_types:
+  activity: activity
+  aerial_photos: aerial_photos
+  basic_page: basic_page
+  cadastral_map: cadastral_map
+  central_forest_reserve: central_forest_reserve
+  district_map: district_map
+  field_books: field_books
+  forest_reserve_boundary: forest_reserve_boundary
+  historical_sheets: historical_sheets
+  meta_data: meta_data
+  satellite_image: satellite_image
+  transparency_maps: transparency_maps


### PR DESCRIPTION
Implemented compulsory revision logs functionality

issue link: https://github.com/National-Forestry-Authority/brms/issues/27

Screenshots: 

<img width="794" alt="Screenshot 2022-11-24 185224" src="https://user-images.githubusercontent.com/58719389/203794770-1818d5af-0c25-4127-9085-e359f781d8a6.png">

<img width="821" alt="Screenshot 2022-11-24 185246" src="https://user-images.githubusercontent.com/58719389/203794789-034b53de-f105-4ad3-b051-3aaa6401849a.png">


