### PR TITLE
#3 : Added meta data explanation fields

### DIFF
--- a/config/sync/core.entity_form_display.node.aerial_photos.default.yml
+++ b/config/sync/core.entity_form_display.node.aerial_photos.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.aerial_photos.field_run_number
     - field.field.node.aerial_photos.field_scale
     - field.field.node.aerial_photos.field_type
+    - field.field.node.aerial_photos.meta_data_explanation
     - node.type.aerial_photos
   module:
     - datetime
@@ -132,6 +133,14 @@ content:
     weight: 129
     region: content
     settings: {  }
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 135
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.cadastral_map.default.yml
+++ b/config/sync/core.entity_form_display.node.cadastral_map.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.cadastral_map.field_surveyed_by
     - field.field.node.cadastral_map.field_traced_by
     - field.field.node.cadastral_map.field_year
+    - field.field.node.cadastral_map.meta_data_explanation
     - node.type.cadastral_map
   module:
     - datetime
@@ -268,6 +269,14 @@ content:
     weight: 135
     region: content
     settings: {  }
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 147
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.central_forest_reserve.default.yml
+++ b/config/sync/core.entity_form_display.node.central_forest_reserve.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.central_forest_reserve.field_nfa_id
     - field.field.node.central_forest_reserve.field_raw_data
     - field.field.node.central_forest_reserve.field_spatial_data_cfr
+    - field.field.node.central_forest_reserve.meta_data_explanation
     - node.type.central_forest_reserve
   module:
     - geofield
@@ -44,6 +45,14 @@ content:
     region: content
     settings:
       geometry_validation: false
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 26
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.district_map.default.yml
+++ b/config/sync/core.entity_form_display.node.district_map.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.district_map.field_sheet_number
     - field.field.node.district_map.field_surveyed_by
     - field.field.node.district_map.field_year
+    - field.field.node.district_map.meta_data_explanation
     - node.type.district_map
   module:
     - datetime
@@ -233,6 +234,14 @@ content:
     weight: 134
     region: content
     settings: {  }
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 143
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.forest_reserve_boundary.default.yml
+++ b/config/sync/core.entity_form_display.node.forest_reserve_boundary.default.yml
@@ -43,6 +43,7 @@ dependencies:
     - field.field.node.forest_reserve_boundary.field_year_of_retracing
     - field.field.node.forest_reserve_boundary.field_year_of_survey
     - field.field.node.forest_reserve_boundary.field_year_of_tracing
+    - field.field.node.forest_reserve_boundary.meta_data_explanation
     - node.type.forest_reserve_boundary
   module:
     - datetime
@@ -384,6 +385,14 @@ content:
     weight: 132
     region: content
     settings: {  }
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 160
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.satellite_image.default.yml
+++ b/config/sync/core.entity_form_display.node.satellite_image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.satellite_image.body
+    - field.field.node.satellite_image.meta_data_explanation
     - node.type.satellite_image
   module:
     - text
@@ -27,6 +28,14 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  meta_data_explanation:
+    type: string_textarea
+    weight: 122
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_view_display.node.aerial_photos.default.yml
+++ b/config/sync/core.entity_view_display.node.aerial_photos.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.aerial_photos.field_run_number
     - field.field.node.aerial_photos.field_scale
     - field.field.node.aerial_photos.field_type
+    - field.field.node.aerial_photos.meta_data_explanation
     - node.type.aerial_photos
   module:
     - datetime
@@ -144,6 +145,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 115
     region: content
 hidden:
   feeds_item: true

--- a/config/sync/core.entity_view_display.node.aerial_photos.teaser.yml
+++ b/config/sync/core.entity_view_display.node.aerial_photos.teaser.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.aerial_photos.field_run_number
     - field.field.node.aerial_photos.field_scale
     - field.field.node.aerial_photos.field_type
+    - field.field.node.aerial_photos.meta_data_explanation
     - node.type.aerial_photos
   module:
     - user
@@ -46,3 +47,4 @@ hidden:
   field_run_number: true
   field_scale: true
   field_type: true
+  meta_data_explanation: true

--- a/config/sync/core.entity_view_display.node.cadastral_map.default.yml
+++ b/config/sync/core.entity_view_display.node.cadastral_map.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.cadastral_map.field_surveyed_by
     - field.field.node.cadastral_map.field_traced_by
     - field.field.node.cadastral_map.field_year
+    - field.field.node.cadastral_map.meta_data_explanation
     - node.type.cadastral_map
   module:
     - datetime
@@ -321,6 +322,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 27
     region: content
 hidden:
   feeds_item: true

--- a/config/sync/core.entity_view_display.node.cadastral_map.teaser.yml
+++ b/config/sync/core.entity_view_display.node.cadastral_map.teaser.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.cadastral_map.field_surveyed_by
     - field.field.node.cadastral_map.field_traced_by
     - field.field.node.cadastral_map.field_year
+    - field.field.node.cadastral_map.meta_data_explanation
     - node.type.cadastral_map
   module:
     - text
@@ -80,3 +81,4 @@ hidden:
   field_surveyed_by: true
   field_traced_by: true
   field_year: true
+  meta_data_explanation: true

--- a/config/sync/core.entity_view_display.node.central_forest_reserve.default.yml
+++ b/config/sync/core.entity_view_display.node.central_forest_reserve.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.central_forest_reserve.field_nfa_id
     - field.field.node.central_forest_reserve.field_raw_data
     - field.field.node.central_forest_reserve.field_spatial_data_cfr
+    - field.field.node.central_forest_reserve.meta_data_explanation
     - node.type.central_forest_reserve
   module:
     - leaflet
@@ -100,6 +101,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden:
   body: true

--- a/config/sync/core.entity_view_display.node.central_forest_reserve.teaser.yml
+++ b/config/sync/core.entity_view_display.node.central_forest_reserve.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.central_forest_reserve.field_nfa_id
     - field.field.node.central_forest_reserve.field_raw_data
     - field.field.node.central_forest_reserve.field_spatial_data_cfr
+    - field.field.node.central_forest_reserve.meta_data_explanation
     - node.type.central_forest_reserve
   module:
     - text
@@ -36,3 +37,4 @@ hidden:
   field_nfa_id: true
   field_raw_data: true
   field_spatial_data_cfr: true
+  meta_data_explanation: true

--- a/config/sync/core.entity_view_display.node.district_map.default.yml
+++ b/config/sync/core.entity_view_display.node.district_map.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.district_map.field_sheet_number
     - field.field.node.district_map.field_surveyed_by
     - field.field.node.district_map.field_year
+    - field.field.node.district_map.meta_data_explanation
     - node.type.district_map
   module:
     - datetime
@@ -219,6 +220,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 123
     region: content
 hidden:
   feeds_item: true

--- a/config/sync/core.entity_view_display.node.district_map.teaser.yml
+++ b/config/sync/core.entity_view_display.node.district_map.teaser.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.district_map.field_sheet_number
     - field.field.node.district_map.field_surveyed_by
     - field.field.node.district_map.field_year
+    - field.field.node.district_map.meta_data_explanation
     - node.type.district_map
   module:
     - user
@@ -64,3 +65,4 @@ hidden:
   field_sheet_number: true
   field_surveyed_by: true
   field_year: true
+  meta_data_explanation: true

--- a/config/sync/core.entity_view_display.node.forest_reserve_boundary.default.yml
+++ b/config/sync/core.entity_view_display.node.forest_reserve_boundary.default.yml
@@ -43,6 +43,7 @@ dependencies:
     - field.field.node.forest_reserve_boundary.field_year_of_retracing
     - field.field.node.forest_reserve_boundary.field_year_of_survey
     - field.field.node.forest_reserve_boundary.field_year_of_tracing
+    - field.field.node.forest_reserve_boundary.meta_data_explanation
     - node.type.forest_reserve_boundary
   module:
     - datetime
@@ -378,6 +379,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 140
     region: content
 hidden:
   feeds_item: true

--- a/config/sync/core.entity_view_display.node.forest_reserve_boundary.teaser.yml
+++ b/config/sync/core.entity_view_display.node.forest_reserve_boundary.teaser.yml
@@ -44,6 +44,7 @@ dependencies:
     - field.field.node.forest_reserve_boundary.field_year_of_retracing
     - field.field.node.forest_reserve_boundary.field_year_of_survey
     - field.field.node.forest_reserve_boundary.field_year_of_tracing
+    - field.field.node.forest_reserve_boundary.meta_data_explanation
     - node.type.forest_reserve_boundary
   module:
     - user
@@ -98,3 +99,4 @@ hidden:
   field_year_of_retracing: true
   field_year_of_survey: true
   field_year_of_tracing: true
+  meta_data_explanation: true

--- a/config/sync/core.entity_view_display.node.satellite_image.default.yml
+++ b/config/sync/core.entity_view_display.node.satellite_image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.satellite_image.body
+    - field.field.node.satellite_image.meta_data_explanation
     - node.type.satellite_image
   module:
     - text
@@ -24,5 +25,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  meta_data_explanation:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 102
     region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.node.satellite_image.teaser.yml
+++ b/config/sync/core.entity_view_display.node.satellite_image.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.satellite_image.body
+    - field.field.node.satellite_image.meta_data_explanation
     - node.type.satellite_image
   module:
     - text
@@ -27,4 +28,5 @@ content:
     third_party_settings: {  }
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  meta_data_explanation: true

--- a/config/sync/field.field.node.aerial_photos.meta_data_explanation.yml
+++ b/config/sync/field.field.node.aerial_photos.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 525207d6-52ea-414d-b5f3-3c2be7b04d6c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.aerial_photos
+id: node.aerial_photos.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: aerial_photos
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.cadastral_map.meta_data_explanation.yml
+++ b/config/sync/field.field.node.cadastral_map.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 0c30459a-dbd4-47c8-b74f-02ae9767747a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.cadastral_map
+id: node.cadastral_map.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: cadastral_map
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.central_forest_reserve.meta_data_explanation.yml
+++ b/config/sync/field.field.node.central_forest_reserve.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 600f4480-f17d-4bd0-81df-88b0ae515ae7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.central_forest_reserve
+id: node.central_forest_reserve.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: central_forest_reserve
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.district_map.meta_data_explanation.yml
+++ b/config/sync/field.field.node.district_map.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 341bd03f-d698-41dd-936e-efd026d09c07
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.district_map
+id: node.district_map.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: district_map
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.forest_reserve_boundary.meta_data_explanation.yml
+++ b/config/sync/field.field.node.forest_reserve_boundary.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 6ab2b8b8-55a1-41e6-8906-d55a2cc2b1db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.forest_reserve_boundary
+id: node.forest_reserve_boundary.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: forest_reserve_boundary
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.satellite_image.meta_data_explanation.yml
+++ b/config/sync/field.field.node.satellite_image.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 2bdea509-c73b-43a3-b128-f4382d3f0b29
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.meta_data_explanation
+    - node.type.satellite_image
+id: node.satellite_image.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+bundle: satellite_image
+label: 'Meta Data Explanation'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.node.meta_data_explanation.yml
+++ b/config/sync/field.storage.node.meta_data_explanation.yml
@@ -1,0 +1,19 @@
+uuid: 8569f434-b6d1-4e0e-bda0-4442dcb263b8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.meta_data_explanation
+field_name: meta_data_explanation
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Added Meta data explanation field on the following datasets

- Aerial photos
- Forest reserve boundaries
- District maps
- Cadastral maps
- Satellite images
- Central Forest Reserves

issue link: https://github.com/National-Forestry-Authority/brms/issues/3

Screenshots:

<img width="1132" alt="Screenshot 2022-11-24 202533" src="https://user-images.githubusercontent.com/58719389/203813912-beb2ec39-125c-4d5c-8590-a51a9ab2dbf7.png">
