### PR TITLE
Issue #141: synchronise polygons from BRMS to Forests

### DIFF
--- a/.ddev/.env
+++ b/.ddev/.env
@@ -1,1 +1,4 @@
 FMS_API_SECRET="this is a test secret"
+FMS_API_AUTH_URL="ddev-forests-web/oauth/token"
+FMS_API_BASE_URL="ddev-forests-web/api"
+FMS_API_CLIENT_ID="brms"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -10,6 +10,7 @@ module:
   breakpoint: 0
   brms_common: 0
   brms_migrate: 0
+  brms_sor: 0
   color_field: 0
   config: 0
   contextual: 0

--- a/web/modules/custom/brms_sor/brms_sor.info.yml
+++ b/web/modules/custom/brms_sor/brms_sor.info.yml
@@ -1,0 +1,5 @@
+name: 'BRMS System of Record'
+type: module
+description: 'Utilities allowing BRMS to act as the system of record for NFA data.'
+package: '@todo Add package'
+core_version_requirement: ^10

--- a/web/modules/custom/brms_sor/brms_sor.module
+++ b/web/modules/custom/brms_sor/brms_sor.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * This is the BRMS System of Record module for sharing data across NFA sites.
+ */
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_update() for node entities.
+ */
+function brms_sor_node_update(NodeInterface $node) {
+  if ($node->getType() == 'forest_reserve') {
+    $service = \Drupal::service('brms_sor.forest_reserve_service');
+
+    // Compare the master polygon with the original to see if it has changed.
+    $polygon = $service->getMasterPolygon($node);
+    $original_polygon = $service->getMasterPolygon($node->original);
+
+    // If there is a master polygon or if there was one that has been removed,
+    // queue it for sending to the FMS.
+    if ($polygon || ($original_polygon && !$polygon)) {
+      $data = [
+        'global_id' => $node->nfa_sites_global_id->value,
+        'polygon' => $polygon,
+      ];
+
+      // Retrieve the 'brms_sor_fms' queue.
+      $queue = \Drupal::queue('brms_sor_fms');
+
+      // Add the data as an item to the queue.
+      $queue->createItem($data);
+    }
+  }
+}

--- a/web/modules/custom/brms_sor/brms_sor.services.yml
+++ b/web/modules/custom/brms_sor/brms_sor.services.yml
@@ -1,0 +1,7 @@
+services:
+  brms_sor.fms_client:
+    class: Drupal\brms_sor\Service\FmsSorApi
+    arguments: ['@http_client', '@logger.factory', '@cache.default', '@key.repository', '@serialization.json', '@datetime.time']
+  brms_sor.forest_reserve_service:
+    class: Drupal\brms_sor\Service\ForestReserveService
+    arguments: ['@entity_type.manager']

--- a/web/modules/custom/brms_sor/config/install/key.key.fms_api.yml
+++ b/web/modules/custom/brms_sor/config/install/key.key.fms_api.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: fms_api
+label: 'FMS API'
+description: 'Client secret key for FMS API'
+key_type: authentication
+key_type_settings: {  }
+key_provider: env
+key_provider_settings:
+  env_variable: FMS_API_SECRET
+  base64_encoded: false
+  strip_line_breaks: true
+key_input: none
+key_input_settings: {  }

--- a/web/modules/custom/brms_sor/src/Plugin/QueueWorker/FmsQueueWorker.php
+++ b/web/modules/custom/brms_sor/src/Plugin/QueueWorker/FmsQueueWorker.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\brms_sor\Plugin\QueueWorker;
+
+use Drupal\brms_sor\Service\FmsSorApi;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines 'brms_sor_fms' queue worker.
+ *
+ * @QueueWorker(
+ *   id = "brms_sor_fms",
+ *   title = @Translation("FMS queue worker"),
+ *   cron = {"time" = 60},
+ * )
+ */
+final class FmsQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Constructs a new SystemOfRecord instance.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected LoggerChannelFactoryInterface $loggerFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected FmsSorApi $client,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('brms_sor.fms_client'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data): void {
+    if (!isset($data['global_id'])) {
+      $this->loggerFactory->get('brms_sor')->error('Missing global_id in queue item.');
+      return;
+    }
+    // Call the API update the polygon of the corresponding CFR in the FMS.
+    $this->client->updateCfrPolygon($data['global_id'], $data['polygon']);
+    // @todo should we keep the item in the queue if the API call fails?
+  }
+
+}

--- a/web/modules/custom/brms_sor/src/Service/FmsSorApi.php
+++ b/web/modules/custom/brms_sor/src/Service/FmsSorApi.php
@@ -1,0 +1,252 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\brms_sor\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\key\KeyRepositoryInterface;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * Implementation of System of Record API interface for FMS.
+ */
+final class FmsSorApi implements SorApiInterface {
+  use StringTranslationTrait;
+
+  /**
+   * GuzzleHttp client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * The JSON serializer service.
+   *
+   * @var \Drupal\Component\Serialization\Json
+   */
+  protected $json;
+
+  /**
+   * The cache backend.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
+   * FMS API auth URL.
+   *
+   * @var string
+   */
+  protected $authUrl;
+
+  /**
+   * FMS API base URL.
+   *
+   * @var string
+   */
+  protected $baseUrl;
+
+  /**
+   * FMS API client id.
+   *
+   * @var string
+   */
+  protected $clientId;
+
+  /**
+   * Secret of the DnB client.
+   *
+   * @var string
+   */
+  protected $clientSecret;
+
+  /**
+   * Constructs a FmsSorApi object.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The GuzzleHttp Client.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   * @param \Drupal\key\KeyRepositoryInterface $key_repository
+   *   The key repository.
+   * @param \Drupal\Component\Serialization\Json $json_service
+   *   The JSON serializer service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   */
+  public function __construct(
+    protected ClientInterface $http_client,
+    protected LoggerChannelFactoryInterface $logger_factory,
+    protected CacheBackendInterface $cache_backend,
+    protected KeyRepositoryInterface $key_repository,
+    protected Json $json_service,
+    protected TimeInterface $time,
+  ) {
+    $this->httpClient = $http_client;
+    $this->logger = $logger_factory;
+    $this->cache = $cache_backend;
+    $this->json = $json_service;
+    $settings = Settings::get('brms_sor');
+    $this->authUrl = $settings['fms_api_auth_url'];
+    $this->baseUrl = $settings['fms_api_base_url'];
+    $this->clientId = $settings['fms_api_client_id'];
+    $this->clientSecret = $key_repository->getKey('fms_api')->getKeyValue();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAccessToken(bool $use_cached_token = TRUE): string {
+    if ($use_cached_token) {
+      $cache_access_token = $this->cache->get('brms_sor_fms_access_token');
+      if ($cache_access_token) {
+        return $cache_access_token->data;
+      }
+    }
+
+    try {
+      $response = $this->httpClient->request('POST', $this->authUrl, [
+        'headers' => [
+          'Content-Type' => 'application/x-www-form-urlencoded',
+        ],
+        'form_params' => [
+          'grant_type' => 'client_credentials',
+          'client_id' => $this->clientId,
+          'client_secret' => $this->clientSecret,
+        ],
+      ]);
+
+      $data = $this->json->decode($response->getBody()->getContents());
+      $this->cache->set('brms_sor_fms_access_token', $data['access_token'], $this->time->getRequestTime() + $data['expires_in']);
+
+      return $data['access_token'];
+    }
+    catch (\Exception $e) {
+      $this->logger->get('brms_sor')->error('Failed to get access token from the FMS API: @message', ['@message' => $e->getMessage()]);
+      throw $e;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get(string $call, array $data = [], bool $use_cached_token = TRUE): array {
+    try {
+      $token = $this->getAccessToken($use_cached_token);
+      $headers = [
+        'Authorization' => 'Bearer ' . $token,
+      ];
+
+      $args = ['headers' => $headers, 'query' => $data];
+      $uri = $this->baseUrl . $call;
+      $this->response = $this->httpClient->get($uri, $args);
+      return $this->json->decode($this->response->getBody()->getContents());
+    }
+    catch (RequestException $e) {
+      $this->response = $e->getResponse();
+      $this->logger->get('brms_sor')->error('Failed to call GET @uri on FMS API: @message',
+        ['@uri' => $uri, '@message' => $e->getMessage()]);
+      // If the token expired, try again with a new token.
+      if ($e->getCode() === 401 && $use_cached_token) {
+        return $this->get($call, $data, FALSE);
+      }
+      else {
+        throw $e;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function patch(string $call, array $data = [], bool $use_cached_token = TRUE): array {
+    try {
+      $token = $this->getAccessToken($use_cached_token);
+      $headers = [
+        'Authorization' => 'Bearer ' . $token,
+        'Content-type' => 'application/vnd.api+json',
+      ];
+
+      $args = ['headers' => $headers, 'json' => $data];
+      $uri = $this->baseUrl . $call;
+      $this->response = $this->httpClient->patch($uri, $args);
+      return $this->json->decode($this->response->getBody()->getContents());
+    }
+    catch (RequestException $e) {
+      $this->response = $e->getResponse();
+      $this->logger->get('brms_sor')->error('Failed to call PATCH @uri on FMS API: @message',
+        ['@uri' => $uri, '@message' => $e->getMessage()]);
+      // If the token expired, try again with a new token.
+      if ($e->getCode() === 401 && $use_cached_token) {
+        return $this->patch($call, $data, FALSE);
+      }
+      else {
+        throw $e;
+      }
+    }
+  }
+
+  /**
+   * Get the UUID of a CFR by its global ID.
+   */
+  public function getCfrUuid(string $cfr_global_id): ?string {
+    try {
+      $response = $this->get('/asset/cfr', ['filter[cfr_global_id]' => $cfr_global_id]);
+      return $response['data'][0]['id'] ?? NULL;
+    }
+    catch (RequestException $e) {
+      $this->logger->get('brms_sor')->error('Failed to get CFR UUID for global ID @cfr_global_id: @message',
+        ['@cfr_global_id' => $cfr_global_id, '@message' => $e->getMessage()]);
+      return NULL;
+    }
+  }
+
+  /**
+   * Update the polygon of a CFR.
+   */
+  public function updateCfrPolygon(string $cfr_global_id, ?string $polygon): void {
+    // Get the UUID of the CFR.
+    $uuid = $this->getCfrUuid($cfr_global_id);
+    if ($uuid) {
+      // Call the API to update the CFR.
+      $body['data'] = [
+        'type' => 'asset',
+        'id' => $uuid,
+        'attributes' => ['intrinsic_geometry' => $polygon],
+      ];
+      try {
+        $response = $this->patch('/asset/cfr/' . $uuid, $body);
+      }
+      catch (RequestException $e) {
+        $this->logger->get('brms_sor')
+          ->error('Failed to update CFR polygon for global ID @cfr_global_id: @message', [
+            '@cfr_global_id' => $cfr_global_id,
+            '@message' => $e->getMessage(),
+          ]);
+      }
+    }
+    else {
+      $this->logger->get('brms_sor')
+        ->error('Failed to update CFR polygon for global ID @cfr_global_id: CFR not found.', [
+          '@cfr_global_id' => $cfr_global_id,
+        ]);
+    }
+  }
+
+}

--- a/web/modules/custom/brms_sor/src/Service/ForestReserveService.php
+++ b/web/modules/custom/brms_sor/src/Service/ForestReserveService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\brms_sor\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Service for retrieving Forest Reserves data.
+ */
+class ForestReserveService {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new ForestReserveService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Get the master polygon for a forest reserve.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The forest reserve node.
+   *
+   * @return string|null
+   *   The master polygon.
+   */
+  public function getMasterPolygon(NodeInterface $node) {
+    if ($node->getType() != 'forest_reserve') {
+      return NULL;
+    }
+
+    $geolayers = $node->get('geolayers')->getValue();
+    foreach ($geolayers as $geolayer) {
+      $geolayerEntity = $this->entityTypeManager->getStorage('geolayer')->load($geolayer['target_id']);
+      $layerType = $geolayerEntity->get('layer_type')->entity;
+
+      if ($layerType && $layerType->getName() == 'Master polygon') {
+        return $geolayerEntity->get('geofield')->value;
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/brms_sor/src/Service/SorApiInterface.php
+++ b/web/modules/custom/brms_sor/src/Service/SorApiInterface.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\brms_sor\Service;
+
+/**
+ * System of Record API interface.
+ */
+interface SorApiInterface {
+
+  /**
+   * Gets a bearer token for accessing the API.
+   *
+   * @return string|null
+   *   The bearer token.
+   *
+   * @throws \GuzzleHttp\Exception\RequestException
+   */
+  public function getAccessToken(bool $use_cached_token = TRUE): ?string;
+
+  /**
+   * Make a GET call to the API.
+   *
+   * @param string $call
+   *   The API call to make.
+   * @param array $data
+   *   Data to provide.
+   * @param bool $use_cached_token
+   *   Whether to use the cached bearer token or generate a new one.
+   *
+   * @return array
+   *   Array of data returned by the API.
+   *
+   * @throws \GuzzleHttp\Exception\RequestException
+   */
+  public function get(string $call, array $data = [], bool $use_cached_token = TRUE): array;
+
+  /**
+   * Make a PATCH call to the API.
+   *
+   * @param string $call
+   *   The API call to make.
+   * @param array $data
+   *   Data to provide.
+   * @param bool $use_cached_token
+   *   Whether to use the cached bearer token or generate a new one.
+   *
+   * @return array
+   *   Array of data returned by the API.
+   *
+   * @throws \GuzzleHttp\Exception\RequestException
+   */
+  public function patch(string $call, array $data = [], bool $use_cached_token = TRUE): array;
+
+}

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -780,6 +780,13 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 
 $settings['config_sync_directory'] = '../config/sync';
 
+// BRMS System of Record variables.
+$settings['brms_sor'] = [
+  'fms_api_base_url' => $_ENV['FMS_API_BASE_URL'],
+  'fms_api_auth_url' => $_ENV['FMS_API_AUTH_URL'],
+  'fms_api_client_id' => $_ENV['FMS_API_CLIENT_ID'],
+];
+
 /**
  * Load local development override configuration, if available.
  *


### PR DESCRIPTION
The PR does the following:

- When a BRMS CFR that has a master polygon is updated, its NFA global id and polygon KML are added to the FMS queue for processing by a queue worker
- When the queue item is processed the queue worker authenticates with the Forests system via the FMS API
- Using the global id it makes a call to get the UUID of the corresponding CFR on forests.
- When it has the UUID it then makes a patch call to update the CFR in Forests